### PR TITLE
Refactor facescan to use local storage for user data

### DIFF
--- a/src/views/login/FaceScan.vue
+++ b/src/views/login/FaceScan.vue
@@ -150,7 +150,7 @@
             >
               <div class="employee-name">{{ employee.name }}</div>
               <div class="employee-id">ID: {{ employee.id }}</div>
-              <div v-if="employee.face" class="face-status">
+              <div v-if="employee.face_signature" class="face-status">
                 Has registered face
               </div>
             </div>
@@ -452,11 +452,12 @@ export default defineComponent({
             emp.finger_print === "undefined"
               ? undefined
               : emp.finger_print || undefined,
-          face:
+          face_signature:
             emp.face_signature === "undefined"
               ? undefined
               : emp.face_signature || undefined,
         }));
+        localStorage.setItem("employeesData", JSON.stringify(this.employees));
       } catch (error) {
         console.error("Failed to fetch employees:", error);
       }
@@ -496,23 +497,23 @@ export default defineComponent({
             `Face registered successfully for ${this.selectedEmployee.name}!`
           );
           try {
-            const baseURL = localStorage.getItem("baseUrl");
-            const token = localStorage.getItem("token");
-            const headers = {
-              Authorization: `Bearer ${token}`,
-              "Content-Type": "application/json",
-            };
-            const url = `${baseURL}/users/${this.selectedEmployee.username}`;
-            const payload = {
-              face_signature: JSON.stringify(Array.from(detection.descriptor)),
-            };
-            await axios.put(url, payload, { headers });
-            this.presentAlert(
-              `Face signature updated successfully for ${this.selectedEmployee.name}!`
-            );
+            let employeesData = JSON.parse(localStorage.getItem("employeesData") || "[]");
+            const employeeIndex = employeesData.findIndex(emp => emp.id === this.selectedEmployee.id);
+
+            if (employeeIndex !== -1) {
+              employeesData[employeeIndex].face_signature = JSON.stringify(Array.from(detection.descriptor));
+              localStorage.setItem("employeesData", JSON.stringify(employeesData));
+              this.presentAlert(
+                `Face signature updated locally for ${this.selectedEmployee.name}!`
+              );
+            } else {
+               this.presentAlert(
+                `Employee not found in local storage!`
+              );
+            }
           } catch (error) {
-            console.error("Error updating face signature:", error);
-            this.presentAlert("Error updating face signature. Please try again.");
+            console.error("Error updating face signature in local storage:", error);
+            this.presentAlert("Error updating face signature in local storage. Please try again.");
           }
           // Clear selection
           this.selectedEmployee = null;
@@ -606,6 +607,8 @@ export default defineComponent({
       await alert.present();
     },
     async performLogin(face) {
+      // This method handles the login process after a face is successfully authenticated.
+      // It dispatches a Vuex action to get a token, and then stores it in localStorage.
       try {
         const employee = face.employee;
         if (!employee) {


### PR DESCRIPTION
This commit refactors the face scan registration process to use local storage as a primary data store for user information, instead of making a PUT request to the server.

Changes:
- The `fetchEmployees` method now stores the fetched user data in `localStorage` under the key `employeesData`.
- The `registerFace` method no longer sends a `PUT` request to the server. Instead, it updates the `face_signature` of the corresponding employee in the `employeesData` stored in `localStorage`.
- The field name used for the face signature has been corrected from `face` to `face_signature` to match the original data structure.

The token generation upon successful authentication is handled by the `performLogin` method, which dispatches the `auth/biometricLogin` Vuex action. This action is responsible for making the API call to get the token and storing it in `localStorage`.