### PR TITLE
fix: Resolve race condition on camera start

### DIFF
--- a/src/views/login/FaceScan.vue
+++ b/src/views/login/FaceScan.vue
@@ -271,12 +271,16 @@ export default defineComponent({
       this.modelsLoaded = true;
       this.loadStoredFaces();
       await this.fetchEmployees();
-      await this.startCamera();
     } catch (error) {
       console.error("Error during component mount:", error);
       await this.presentAlert("Initialization failed. Please refresh the page.");
     } finally {
       this.loading = false;
+      this.$nextTick(async () => {
+        if (this.modelsLoaded) {
+          await this.startCamera();
+        }
+      });
     }
   },
   methods: {


### PR DESCRIPTION
This commit fixes a race condition in the `FaceScan.vue` component that occurred when starting the camera. The error `TypeError: Cannot set properties of null (setting 'srcObject')` was caused by attempting to access the video element before it was available in the DOM.

The fix utilizes `this.$nextTick` to ensure that the `startCamera()` method is called only after the loading indicator has been removed and the DOM has been updated. This guarantees that the video element exists before its `srcObject` is set, resolving the bug.